### PR TITLE
BLOB fields get corrupted

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,0 +1,5 @@
+  * Pass BLOBs correctly.
+  * Make Kwalitee happier.
+
+0.1.0
+  * Initial CPAN release.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,6 +25,7 @@ WriteMakefile(
         'DBD::MariaDB' => '>= 1.00',
         'DBIx::Class'  => '>= 0.082820',
         'DBI'          => 0,
+        'perl'         => '>= 5.8.9',
     },
     TEST_REQUIRES => {
         'Test::More'      => 0,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,6 +19,9 @@ WriteMakefile(
                 web => "https://github.com/Siemplexus/DBIx-Class-Storage-DBI-MariaDB/issues",
             },
         },
+        x_contributors => [
+          'Dave Lambley <dave@lambley.me.uk>',
+        ],
     },
     VERSION_FROM => "lib/DBIx/Class/Storage/DBI/MariaDB.pm",
     PREREQ_PM    => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,6 +24,7 @@ WriteMakefile(
     PREREQ_PM    => {
         'DBD::MariaDB' => '>= 1.00',
         'DBIx::Class'  => '>= 0.082820',
+        'DBI'          => 0,
     },
     TEST_REQUIRES => {
         'Test::More'      => 0,

--- a/lib/DBIx/Class/Storage/DBI/MariaDB.pm
+++ b/lib/DBIx/Class/Storage/DBI/MariaDB.pm
@@ -3,6 +3,7 @@ package DBIx::Class::Storage::DBI::MariaDB;
 use strict;
 use warnings;
 
+use DBI;
 use base qw/DBIx::Class::Storage::DBI/;
 
 our $VERSION = '0.1.0';
@@ -171,6 +172,13 @@ sub lag_behind_master {
     return
       shift->_get_dbh->selectrow_hashref('show slave status')
       ->{Seconds_Behind_Master};
+}
+
+sub bind_attribute_by_data_type {
+    if ( $_[1] = ~ /^(?:tiny|medium|long)blob$/i ) {
+        return DBI::SQL_BINARY;
+    }
+    return;
 }
 
 1;

--- a/t/01-operations.t
+++ b/t/01-operations.t
@@ -30,7 +30,8 @@ $dbh->do(
     artistid INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY, 
     name VARCHAR(100),
     rank INTEGER NOT NULL DEFAULT 13,
-    charfield CHAR(10)
+    charfield CHAR(10),
+    picture MEDIUMBLOB
 )"
 );
 $dbh->do("DROP TABLE IF EXISTS owner");
@@ -397,6 +398,17 @@ subtest 'mariadb_auto_reconnect' => sub {
     ok( !defined $orig_dbh,
         'DBIC operation triggered reconnect - old $dbh is gone' );
     ok( $rs->find( { name => "test" } ), 'Expected row created' );
+};
+
+subtest 'blob round trip' => sub {
+    my $new =
+      $schema->resultset('Artist')->create( { name => 'blob round trip', picture => "\302\243" } );
+    ok( $new->artistid, 'Auto-PK worked' );
+
+    my $artist2_rs =
+      $schema->resultset('Artist')->search( { artistid => $new->artistid } );
+
+    is($artist2_rs->single->picture, "\302\243", "Round-tripped a blob");
 };
 
 done_testing;

--- a/t/lib/MyApp/Schema.pm
+++ b/t/lib/MyApp/Schema.pm
@@ -25,6 +25,10 @@ __PACKAGE__->add_columns(
         size        => 10,
         is_nullable => 1,
     },
+    picture => {
+        data_type   => 'MEDIUMBLOB',
+        is_nullable => 1,
+    },
 );
 __PACKAGE__->set_primary_key('artistid');
 __PACKAGE__->add_unique_constraint( ['name'] );


### PR DESCRIPTION
Hello,

I have hit a bug in in this module in which BLOB fields are corrupted when they are transferred to the server. This happens because when blobs are transferred the bytes _should_ be transferred raw, and not use the character encoding of the connection. This can only happen if the database driver knows that a field is a BLOB.

I have thus made this module provide the type hint to DBIx::Class, which in turn provided it to the database driver. This cases the new unit test to pass.

I have also added some metadata to make Kwalitee a little more happy.

All the best,
Dave