### PR TITLE
Fix behaviour for Unicode text

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+  * Fix breaking of non-ASCII unicode in previous release.
+
 0.1.1
   * Pass BLOBs correctly.
   * Make Kwalitee happier.

--- a/lib/DBIx/Class/Storage/DBI/MariaDB.pm
+++ b/lib/DBIx/Class/Storage/DBI/MariaDB.pm
@@ -175,7 +175,7 @@ sub lag_behind_master {
 }
 
 sub bind_attribute_by_data_type {
-    if ( $_[1] = ~ /^(?:tiny|medium|long)blob$/i ) {
+    if ( $_[1] =~ /^(?:tiny|medium|long)blob$/i ) {
         return DBI::SQL_BINARY;
     }
     return;

--- a/t/01-operations.t
+++ b/t/01-operations.t
@@ -402,13 +402,14 @@ subtest 'mariadb_auto_reconnect' => sub {
 
 subtest 'blob round trip' => sub {
     my $new =
-      $schema->resultset('Artist')->create( { name => 'blob round trip', picture => "\302\243" } );
+      $schema->resultset('Artist')->create( { name => 'blob round trip', picture => "\302\243", name => "\302\243" } );
     ok( $new->artistid, 'Auto-PK worked' );
 
     my $artist2_rs =
       $schema->resultset('Artist')->search( { artistid => $new->artistid } );
 
     is($artist2_rs->single->picture, "\302\243", "Round-tripped a blob");
+    is($artist2_rs->single->name,    "\302\243", "Round-tripped non-ASCII characters");
 };
 
 done_testing;

--- a/t/01-operations.t
+++ b/t/01-operations.t
@@ -412,4 +412,17 @@ subtest 'blob round trip' => sub {
     is($artist2_rs->single->name,    "\302\243", "Round-tripped non-ASCII characters");
 };
 
+# We don't want to assume that the database has defaulted to utf8mb4, so we
+# only test with a >255 basic multilingual plane character.
+subtest 'basic multilingual plane round trip' => sub {
+    my $new =
+      $schema->resultset('Artist')->create( { name => chr(0x2603) } );
+    ok( $new->artistid, 'Auto-PK worked' );
+
+    my $artist2_rs =
+      $schema->resultset('Artist')->search( { artistid => $new->artistid } );
+
+    is($artist2_rs->single->name, chr(0x2603), "Round-tripped a snowman");
+};
+
 done_testing;


### PR DESCRIPTION
I'm afraid I introduced some white space in the wrong place in https://github.com/Siemplexus/DBIx-Class-Storage-DBI-MariaDB/pull/5

This change should restore correct passing of Unicode text.