### PR TITLE
Also handle plain "BLOB" type as binary

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+  * Pass plain "BLOB" type as binary.
+
 0.1.2
   * Fix breaking of non-ASCII unicode in previous release.
 

--- a/lib/DBIx/Class/Storage/DBI/MariaDB.pm
+++ b/lib/DBIx/Class/Storage/DBI/MariaDB.pm
@@ -175,7 +175,7 @@ sub lag_behind_master {
 }
 
 sub bind_attribute_by_data_type {
-    if ( $_[1] =~ /^(?:tiny|medium|long)blob$/i ) {
+    if ( $_[1] =~ /^(?:tiny|medium|long|)blob$/i ) {
         return DBI::SQL_BINARY;
     }
     return;

--- a/t/03-types.t
+++ b/t/03-types.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+
+my $class = "DBIx::Class::Storage::DBI::MariaDB";
+use_ok $class;
+
+my @untyped = qw/
+  int
+  text
+  mediumtext
+  json
+  /;
+my @typed = qw/
+  blob
+  tinyblob
+  mediumblob
+  longblob
+  /;
+
+for my $s ( map { $_ => uc($_) } @untyped ) {
+    is( scalar( $class->bind_attribute_by_data_type($s) ), undef,
+        "No type for $s" );
+}
+
+for my $s ( map { $_ => uc($_) } @typed ) {
+    is( $class->bind_attribute_by_data_type($s),
+        DBI::SQL_BINARY, "Type for $s" );
+}
+
+done_testing();


### PR DESCRIPTION
Hello,

This change adds handling of the plain `BLOB` type. The full list of BLOBs should now be handled.
https://mariadb.com/kb/en/blob-and-text-data-types/